### PR TITLE
Fixed relative paths.

### DIFF
--- a/bin/run_command_server.sh
+++ b/bin/run_command_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WORKDIR=${WORKDIR:=`pwd`}
+WORKDIR=${WORKDIR:=$(dirname `pwd`)}
 PYTHONPATH=$WORKDIR/src
 export PYTHONPATH
 

--- a/src/command_server.py
+++ b/src/command_server.py
@@ -80,7 +80,9 @@ class HttpCommandServer(object):
 
 if __name__ == '__main__':
     config = configparser.ConfigParser()
-    config.read('etc/command_server.conf')
+    config_file = os.path.join(os.path.dirname(os.getcwd()),
+                               'etc', 'command_server.conf')
+    config.read(config_file)
     host = config.get('commandServer', 'host')
     port = os.environ.get('PORT', config.get('commandServer', 'port'))
     static_path = config.get('commandServer', 'static_path')


### PR DESCRIPTION
Currently, after cloning the repo, you can not start the server, because of wrong relative paths.
